### PR TITLE
Allow NavBar Menu in Settings

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -23,7 +23,7 @@
 
     <!-- Whether a software navigation bar should be shown. NOTE: in the future this may be
          autodetected from the Configuration. -->
-    <bool name="config_showNavigationBar">false</bool>
+    <bool name="config_showNavigationBar">true</bool>
 
     <!-- XXXXX NOTE THE FOLLOWING RESOURCES USE THE WRONG NAMING CONVENTION.
          Please don't copy them, copy anything else. -->


### PR DESCRIPTION
I'm a potential new contributor for t0lte, not sure if I have understood the build process completely. I'd like to allow t0lte users to enable the NavBar via preferences in settings. Currently these are hidden from t0lte users. I don't want to enable the navbar by default, but give users the option by having it disabled by default, but enable the preferences for the NavBar. Similar to how Samsung Galaxy S4 devices have the NavBar disabled by default, but allow users to easily change a preference to enable it.
